### PR TITLE
fix compiler error on Xcode 26

### DIFF
--- a/Sources/CombineBonjour/NWEndpointPublisher.swift
+++ b/Sources/CombineBonjour/NWEndpointPublisher.swift
@@ -90,7 +90,7 @@ extension NWEndpointPublisher {
     public enum ResolvedEndpoint: Equatable {
         public enum HostType: Equatable {
             case name(String)
-            case ip(IP)
+            case ip(NetworkExtensions.IP)
         }
 
         /// A host port endpoint represents an endpoint defined by the host and port.


### PR DESCRIPTION
There is a type name collision with Network.IP